### PR TITLE
fix: reflect spec for `EXT` and `TUP` flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository aims at providing an up-to-date implementation of the [Weiroll V
 ## Changelog
 
 - Using foundry instead of hardhat for the development environment.
-- Reflect specs for `EXT` and `TUP` flags in the command structure. #1
+- Reflect specs for `EXT` and `TUP` flags in the command structure. [#1](https://github.com/dantop114/weiroll-foundry/pull/1)
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,10 @@ Weiroll is a simple and efficient operation-chaining/scripting language for the 
 
 This repository aims at providing an up-to-date implementation of the [Weiroll VM](https://github.com/weiroll/weiroll).
 
-
 ## Changelog
 
 - Using foundry instead of hardhat for the development environment.
-
+- Reflect specs for `EXT` and `TUP` flags in the command structure. #1
 
 ## Documentation
 
@@ -38,11 +37,11 @@ Each command is a `bytes32` containing the following fields (MSB first):
 └───────┴─┴───────────┴─┴───────────────────────────────────────┘
 ```
 
- - `sel` is the 4-byte function selector to call
- - `f` is a flags byte that specifies calltype, and whether this is an extended command
- - `in` is an array of 1-byte argument specifications described below, for the input arguments
- - `o` is the 1-byte argument specification described below, for the return value
- - `target` is the address to call
+- `sel` is the 4-byte function selector to call
+- `f` is a flags byte that specifies calltype, and whether this is an extended command
+- `in` is an array of 1-byte argument specifications described below, for the input arguments
+- `o` is the 1-byte argument specification described below, for the return value
+- `target` is the address to call
 
 ### Flags
 
@@ -78,7 +77,6 @@ The 2-bit `calltype` is treated as a `uint16` that specifies the type of call. T
 If `calltype` equals `CALL with value`, then the first argument in the `in` input list is taken to be the amount of ETH that will be supplied to the call, and the rest of the arguments are the arguments to the called function, both processed as described below.
 
 ### Input/output list (in/o) format
-
 
 Each 1-byte argument specifier value describes how each input or output argument should be treated, and has the following fields (MSB first):
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository aims at providing an up-to-date implementation of the [Weiroll V
 ## Changelog
 
 - Using foundry instead of hardhat for the development environment.
-- Reflect specs for `EXT` and `TUP` flags in the command structure. [#1](https://github.com/dantop114/weiroll-foundry/pull/1)
+- Reflect specs for `EXT` and `TUP` flags in the command structure. [GH-1](https://github.com/dantop114/weiroll-foundry/pull/1)
 
 ## Documentation
 

--- a/src/VM.sol
+++ b/src/VM.sol
@@ -14,8 +14,8 @@ abstract contract VM {
     uint256 constant FLAG_CT_STATICCALL = 0x02;
     uint256 constant FLAG_CT_VALUECALL = 0x03;
     uint256 constant FLAG_CT_MASK = 0x03;
-    uint256 constant FLAG_EXTENDED_COMMAND = 0x80;
-    uint256 constant FLAG_TUPLE_RETURN = 0x40;
+    uint256 constant FLAG_EXTENDED_COMMAND = 0x40;
+    uint256 constant FLAG_TUPLE_RETURN = 0x80;
 
     uint256 constant SHORT_COMMAND_FILL = 0x000000000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
 

--- a/test/Tupler.t.sol
+++ b/test/Tupler.t.sol
@@ -26,7 +26,7 @@ contract TuplerTest is Test {
     /// @dev Should perform a tuple return that's sliced before being fed to another function (first var)
     function test_tupler1() public {
         bytes32 command1 = WeirollPlanner.buildCommand(
-            MultiReturn.intTuple.selector, 0x41, bytes6(0xff0000000000), bytes1(0x00), address(multiReturn__)
+            MultiReturn.intTuple.selector, 0x81, bytes6(0xff0000000000), bytes1(0x00), address(multiReturn__)
         );
 
         bytes32 command2 = WeirollPlanner.buildCommand(
@@ -55,7 +55,7 @@ contract TuplerTest is Test {
     /// @dev Should perform a tuple return that's sliced before being fed to another function (second var)
     function test_tupler2() public {
         bytes32 command1 = WeirollPlanner.buildCommand(
-            MultiReturn.intTuple.selector, 0x41, bytes6(0xff0000000000), bytes1(0x00), address(multiReturn__)
+            MultiReturn.intTuple.selector, 0x81, bytes6(0xff0000000000), bytes1(0x00), address(multiReturn__)
         );
 
         bytes32 command2 = WeirollPlanner.buildCommand(


### PR DESCRIPTION
From the specs:

https://github.com/dantop114/weiroll-foundry/blob/fa24c42c23d8a2bae16319e0424cd5fe063ed313/README.md?plain=1#L49-L64

In the code the flags were flipped.