### PR TITLE
feat: use `mcopy` instead of identity precompile

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository aims at providing an up-to-date implementation of the [Weiroll V
 - Using foundry instead of hardhat for the development environment.
 - Reflect specs for `EXT` and `TUP` flags in the command structure. [GH-1](https://github.com/dantop114/weiroll-foundry/pull/1)
 - Use custom errors instead of `require` statements. [GH-2](https://github.com/dantop114/weiroll-foundry/pull/2)
+- Use `mcopy` instead of identity precompile for copying memory. [GH-3](https://github.com/dantop114/weiroll-foundry/pull/3)
 
 ## Documentation
 

--- a/src/CommandBuilder.sol
+++ b/src/CommandBuilder.sol
@@ -23,7 +23,7 @@ library CommandBuilder {
     /// @dev Build the input data for a call.
     function buildInputs(bytes[] memory state, bytes4 selector, bytes32 indices)
         internal
-        view
+        pure
         returns (bytes memory ret)
     {
         uint256 count; // Number of bytes in whole ABI encoded message
@@ -143,11 +143,12 @@ library CommandBuilder {
     }
 
     /// @dev Write a tuple to the state.
-    function writeTuple(bytes[] memory state, bytes1 index, bytes memory output) internal view {
+    function writeTuple(bytes[] memory state, bytes1 index, bytes memory output) internal pure {
         uint256 idx = uint256(uint8(index));
         if (idx == IDX_END_OF_ARGS) return;
 
         bytes memory entry = state[idx] = new bytes(output.length + 32);
+
         memcpy(output, 0, entry, 32, output.length);
         assembly {
             let l := mload(output)
@@ -156,9 +157,9 @@ library CommandBuilder {
     }
 
     /// @dev Copy memory from one location to another.
-    function memcpy(bytes memory src, uint256 srcidx, bytes memory dest, uint256 destidx, uint256 len) internal view {
+    function memcpy(bytes memory src, uint256 srcidx, bytes memory dest, uint256 destidx, uint256 len) internal pure {
         assembly {
-            pop(staticcall(gas(), 4, add(add(src, 32), srcidx), len, add(add(dest, 32), destidx), len))
+            mcopy(add(add(dest, 32), destidx), add(add(src, 32), srcidx), len)
         }
     }
 }

--- a/src/test/CommandBuilderHarness.sol
+++ b/src/test/CommandBuilderHarness.sol
@@ -25,7 +25,7 @@ contract CommandBuilderHarness {
 
     function testBuildInputs(bytes[] memory state, bytes4 selector, bytes32 indices)
         public
-        view
+        pure
         returns (bytes memory)
     {
         bytes memory input = state.buildInputs(selector, indices);
@@ -35,7 +35,7 @@ contract CommandBuilderHarness {
 
     function testWriteOutputs(bytes[] memory state, bytes1 index, bytes memory output)
         public
-        view
+        pure
         returns (bytes[] memory, bytes memory)
     {
         state = state.writeOutputs(index, output);


### PR DESCRIPTION
Since the [Cancun upgrade](https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/cancun.md) we can use `mcopy` introduced in [EIP-5656](https://eips.ethereum.org/EIPS/eip-5656).

This is beneficial especially when using dynamic length data.