### PR TITLE
feat: `VERBATIM` flag

### DIFF
--- a/src/test/Fallback.sol
+++ b/src/test/Fallback.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Unlicensed
+pragma solidity 0.8.28;
+
+import {Events} from "./Events.sol";
+
+contract Fallback is Events {
+    receive() external payable {
+        if (msg.value > 0) emit LogUint(msg.value);
+    }
+
+    fallback() external payable {
+        if (msg.value > 0) emit LogUint(msg.value);
+        if (msg.data.length > 0) emit LogBytes(msg.data);
+    }
+}


### PR DESCRIPTION
name was inspired by this: https://docs.soliditylang.org/en/latest/yul.html#verbatim

this feature was introduced in the original weiroll machine but never merged to main (see [the PR](https://github.com/weiroll/weiroll/pull/96/files))

also introduced later by the [enso-weiroll](https://github.com/EnsoFinance/enso-weiroll/tree/main) as `DATA_FLAG`