### PR TITLE
Update Solidity version pragma to use caret notation

### DIFF
--- a/src/CommandBuilder.sol
+++ b/src/CommandBuilder.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.28;
+pragma solidity ^0.8.28;
 
 library CommandBuilder {
     uint256 constant IDX_VARIABLE_LENGTH = 0x80;

--- a/src/VM.sol
+++ b/src/VM.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.28;
+pragma solidity ^0.8.28;
 
 import {CommandBuilder} from "./CommandBuilder.sol";
 


### PR DESCRIPTION
I'm trying to use this in my project that uses 0.8.33. This hard pin is getting in the way.